### PR TITLE
Correct typo in the Introduction

### DIFF
--- a/vism/book.6.tei
+++ b/vism/book.6.tei
@@ -1200,7 +1200,7 @@
             <pb ed="BPS2011" pdf_page="42" n="xl"/>
             <span>confute nor confirm the </span>
             <em>Mahāvaṃsa </em>
-            <span>statement than he was born in Magadha (see note 8). The Sri Lankan Chronicles survived the historical criticism to which they were subjected in the last hundred years. The independent evidence that could be brought to bear supported them, and Western scholars ended by pronouncing them reliable in essentials. The account just quoted is considered to be based on historical fact even if it contains legendary matter.</span>
+            <span>statement that he was born in Magadha (see note 8). The Sri Lankan Chronicles survived the historical criticism to which they were subjected in the last hundred years. The independent evidence that could be brought to bear supported them, and Western scholars ended by pronouncing them reliable in essentials. The account just quoted is considered to be based on historical fact even if it contains legendary matter.</span>
           </p>
           <p y="131" x="41" page_id="42" page_no="xl">
             <span>It is not possible to make use of the body of Bhadantācariya Buddhaghosa’s works to test the </span>


### PR DESCRIPTION
As a native English speaker I know this is wrong, but I lack the grammatical knowledge to explain why on a technical level. I resorted to using GPT to explain why:

> 'The word “than” is used in comparative structures, while “that” is used to introduce a clause, often a clause of indirect speech or a clause that gives extra information about something. In this case, “that” is introducing extra information about the Mahāvaṃsa statement, so it is the correct word to use.'